### PR TITLE
Made some changes to how TriggerManager.java handles the events:

### DIFF
--- a/src/main/java/cat/TRIGGER/TriggerManager.java
+++ b/src/main/java/cat/TRIGGER/TriggerManager.java
@@ -212,9 +212,9 @@ public class TriggerManager {
     }
 
     public void registerEvents(EventNode<Event> handler) {
-        handler.addListener(PlayerMoveEvent.class, this::playerMoveEvent);
-        handler.addListener(EntityTeleportEvent.class, this::entityTeleportEvent);
-        handler.addListener(EntitySpawnEvent.class, this::entitySpawnEvent);
+        handler.addListener(PlayerMoveEvent.class, this::playerMoveEvent)
+                .addListener(EntityTeleportEvent.class, this::entityTeleportEvent)
+                .addListener(EntitySpawnEvent.class, this::entitySpawnEvent);
     }
 
     /**


### PR DESCRIPTION
This pull request is for some fixes with the event system, currently it is only checked on move, I have added two events, Teleporting (checks if they are leaving or entering a new area on teleport) and Spawning (checks only if they are entering a new area on spawn). This will ensure that even if a player enters an area through something like teleportation or spawning the entered/leaving callback will be called and not just the tick callback once they start moving.

My commit removes the implemented Consumer and replaces it with three methods:

```Java
TriggerManager#playerMoveEvent(PlayerMoveEvent event) 
```
```Java
TriggerManager#entityTeleportEvent(EntityTeleportEvent event)
```
```Java
TriggerManager#entitySpawnEvent(EntitySpawnEvent event)
```

These can be called by the event manager similarly to how it was originally:

```Java
TriggerManager triggers = /* New TriggerManager */
EventNode#addListener(PlayerMoveEvent.class, triggers::playerMoveEvent); 
EventNode#addListener(EntityTeleportEvent.class, triggers::entityTeleportEvent); 
EventNode#addListener(EntitySpawnEvent.class, triggers::entitySpawnEvent);
```

OR I added a new registerEvents method:

```Java
triggers.registerEvents(/* EventNode */);
```