### PR TITLE
Codec Support

### DIFF
--- a/src/main/java/cat/TRIGGER/TriggerGlobals.java
+++ b/src/main/java/cat/TRIGGER/TriggerGlobals.java
@@ -12,6 +12,22 @@ package cat.TRIGGER;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import net.kyori.adventure.text.*;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.ShadowColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.util.ARGBLike;
+import net.kyori.adventure.util.RGBLike;
+import net.minestom.server.codec.Codec;
+import net.minestom.server.codec.Result;
+import net.minestom.server.codec.StructCodec;
+import net.minestom.server.codec.Transcoder;
+import net.minestom.server.color.AlphaColor;
+import net.minestom.server.color.Color;
+import net.minestom.server.color.DyeColor;
+import net.minestom.server.coordinate.Vec;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A collection of global objects that are used across the system.
@@ -19,4 +35,33 @@ import com.google.gson.GsonBuilder;
 public final class TriggerGlobals {
     public static TriggerTypeAdapter triggerTypeAdapter = new TriggerTypeAdapter();
     public static Gson GSON = new GsonBuilder().setPrettyPrinting().registerTypeAdapter(Trigger.class, triggerTypeAdapter).create();
+
+    /**
+     * A note about RGB_CODEC, since it is using an interface it needs to
+     * boiled down to one of the implementations, I have chosen TextColor
+     * arbitrarily, but DyeColor, or Color would work the same.
+     **/
+    private static Codec<RGBLike> RGB_CODEC = StructCodec.struct(
+            "red", Codec.INT, RGBLike::red,
+            "green", Codec.INT, RGBLike::green,
+            "blue", Codec.INT, RGBLike::blue,
+            TextColor::color
+    );
+
+    private static Codec<Vec> VEC_CODEC = StructCodec.struct(
+            "x", Codec.DOUBLE, Vec::x,
+            "y", Codec.DOUBLE, Vec::y,
+            "z", Codec.DOUBLE, Vec::z,
+            Vec::new
+    );
+
+    public static Codec<Trigger> TRIGGER_CODEC = StructCodec.struct(
+            "anchors", VEC_CODEC.list(), Trigger::getAnchors,
+            "position", VEC_CODEC, Trigger::getPosition,
+            "uuid", Codec.UUID, Trigger::getUuid,
+            "name", Codec.COMPONENT, Trigger::getName,
+            "color", RGB_CODEC, Trigger::getColor,
+            "callback", null, null,
+            Trigger::new
+    );
 }


### PR DESCRIPTION
Added Codec Support through Minestom's built in codec system and put it in TriggerGlobals

```Java

// Encoding the trigger
Trigger trigger = /*Create Trigger*/;
Result<BinaryTag> tag = TriggerGlobals.CODEC.encode(Transcoder.NBT, trigger);

// Decoding the trigger
Result<Trigger> triggerResult = TriggerGlobals.CODEC.decode(Transcoder.NBT, /* Some form of data */);
```


As a note, I do have a system for saving Callbacks, but I am currently not going to put that in the public github as it is a bit janky and requires you to turn consumers into just plain strings and I want to find another way to allow for consumers to be used like normally if possible at all